### PR TITLE
Remove escape of &- and note ways to handle &

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ public class UnicodeEncoder {
 
 ## Caveats
 
-The encoding system uses the characters `&` and `-` to demarcate encoded text, which means that there is the potential for those characters within otherwise normal text to be handled wierdly. Make sure to test these segments with care.
+The encoding system uses the characters `&` and `-` to demarcate encoded text, which means that there is the potential for those characters within otherwise normal text to be handled wierdly. This can be obviated by encoding any text with `&` in it.
 
 The encoded text will be displayed on the device before being decoded. This might look strange, but without it there is no way to handle the `&` and `-` characters reliably. Testing will work even with the intermediate display.
 

--- a/src/io/appium/android/ime/UnicodeIME.java
+++ b/src/io/appium/android/ime/UnicodeIME.java
@@ -102,11 +102,6 @@ public class UnicodeIME extends InputMethodService {
         isShifted = false;
         unicodeString.append(M_UTF7_UNSHIFT);
         String decoded = decodeUtf7(unicodeString.toString());
-        if (unicodeString.toString().equals("&-")) {
-            // this handles the case where the shift and unshift chars are
-            // inputed by the user with nothing intervening
-            decoded = unicodeString.toString();
-        }
         getCurrentInputConnection().commitText(decoded, 1);
         unicodeString = null;
     }


### PR DESCRIPTION
If `&` is encoded before sending, it will come out right. So no need to handle `&-` specifically.
