### PR TITLE
Pass along key event to both key up and key down

### DIFF
--- a/src/io/appium/android/ime/UnicodeIME.java
+++ b/src/io/appium/android/ime/UnicodeIME.java
@@ -111,7 +111,7 @@ public class UnicodeIME extends InputMethodService {
     public boolean onKeyUp(int keyCode, KeyEvent event) {
         Log.i(TAG, "onKeyUp (keyCode='" + keyCode + "', event.keyCode='" + event.getKeyCode() + "', metaState='" + event.getMetaState() + "')");
         metaState = MetaKeyKeyListener.handleKeyUp(metaState, keyCode, event);
-        return true;
+        return super.onKeyUp(keyCode, event);
     }
 
     private void shift() {


### PR DESCRIPTION
We were not passing the `keyUp` event to super, so it was not being handled which on the odd case caused problems.